### PR TITLE
(maint) Fix-ups for some errors I ran into

### DIFF
--- a/configs/components/rubygem-bootsnap.rb
+++ b/configs/components/rubygem-bootsnap.rb
@@ -1,6 +1,6 @@
 component 'rubygem-bootsnap' do |pkg, settings, platform|
   pkg.version '1.7.2'
-  pkg.md5sum '3c16afcb468f7e98c9d5e93f8db1b29f'
+  pkg.md5sum 'dc8b1a2fc84e9a9f3e8934294418692d'
 
   pkg.build_requires 'rubygem-msgpack'
   

--- a/configs/components/rubygem-msgpack.rb
+++ b/configs/components/rubygem-msgpack.rb
@@ -1,9 +1,11 @@
 component 'rubygem-msgpack' do |pkg, settings, platform|
-  pkg.version '1.4.2'
   
   if platform.is_windows?
+    # Version 1.4.2 did not publish a mingw version
+    pkg.version '1.3.3'
     pkg.md5sum '8f5f47873696caf069f2076a2e0722d5'
   else
+    pkg.version '1.4.2'
     pkg.md5sum 'f58a6aace36cd82e9a39ffeeef925afc'
   end
 


### PR DESCRIPTION
This updates an md5 sum that seemed to be wrong, and uses msgpack 1.3.3
since 1.4.2 did not publish a mingw version.